### PR TITLE
No fixed seed for random port number

### DIFF
--- a/shared/configuration/src/main/java/com/github/signed/inmemory/shared/configuration/RandomUserPort.java
+++ b/shared/configuration/src/main/java/com/github/signed/inmemory/shared/configuration/RandomUserPort.java
@@ -8,14 +8,12 @@ import java.util.Random;
  */
 public class RandomUserPort implements Port {
 
-    private static final Random random = new Random(341882349);
-
     private final int port;
 
     public RandomUserPort() {
         int from = 1024;
         int to = 49151;
-        port = from + random.nextInt(to - from + 1);
+        port = from + new Random().nextInt(to - from + 1);
     }
 
     @Override


### PR DESCRIPTION
If random port numbers are used in different VMs at the same time, port collisions are very likely with a fixed seed random number generator. I have disabled the fixed seed.
